### PR TITLE
Fix error for thermostats set to Program/Auto

### DIFF
--- a/custom_components/watts_vision/climate.py
+++ b/custom_components/watts_vision/climate.py
@@ -9,6 +9,7 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_OFF,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
+    HVAC_MODE_AUTO,
     PRESET_BOOST,
     PRESET_COMFORT,
     PRESET_ECO,


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 455, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 731, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 823, in add_to_platform_finish
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 568, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 632, in _async_write_ha_state
    state = self._stringify_state(available)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 574, in _stringify_state
    if (state := self.state) is None:
  File "/usr/src/homeassistant/homeassistant/components/climate/__init__.py", line 242, in state
    if self.hvac_mode is None:
  File "/config/custom_components/watts_vision/climate.py", line 110, in hvac_mode
    return self._attr_hvac_mode
AttributeError: 'WattsThermostat' object has no attribute '_attr_hvac_mode'