### PR TITLE
Change sensor name to start with zone name

### DIFF
--- a/custom_components/watts_vision/binary_sensor.py
+++ b/custom_components/watts_vision/binary_sensor.py
@@ -51,7 +51,7 @@ class WattsVisionHeatingBinarySensor(BinarySensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = "Heating " + zone
+        self._name = zone + " Heating"
         self._state: bool = False
         self._available = True
 

--- a/custom_components/watts_vision/climate.py
+++ b/custom_components/watts_vision/climate.py
@@ -68,7 +68,7 @@ class WattsThermostat(ClimateEntity):
         self.id = id
         self.zone = zone
         self.deviceID = deviceID
-        self._name = "Thermostat " + zone
+        self._name = zone + " Thermostat"
         self._available = True
         self._attr_extra_state_attributes = {"previous_gv_mode": "0"}
 

--- a/custom_components/watts_vision/sensor.py
+++ b/custom_components/watts_vision/sensor.py
@@ -87,7 +87,7 @@ class WattsVisionThermostatSensor(SensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = "Heating mode " + zone
+        self._name = zone + " Heating mode"
         self._state = None
         self._available = True
 
@@ -147,7 +147,7 @@ class WattsVisionBatterySensor(SensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = "Battery " + zone
+        self._name = zone + " Battery"
         self._state = None
         self._available = None
 
@@ -201,7 +201,7 @@ class WattsVisionTemperatureSensor(SensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = "Air temperature " + zone
+        self._name = zone + " Air temperature"
         self._state = None
         self._available = True
 
@@ -262,7 +262,7 @@ class WattsVisionSetTemperatureSensor(SensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = "Target temperature " + zone
+        self._name = zone + " Target temperature"
         self._state = None
         self._available = True
 


### PR DESCRIPTION
Allows home assistant to shorten (repetitive parts of) sensor names in e.g. overview dashboard

While this is a preference, I stupidly based some fixes off this commit in my personal branch... So need an open mind on this change or back it out of the PR's with actual fixes...