### PR TITLE
Refactor to facilitate correct Heating state in Program mode

### DIFF
--- a/custom_components/watts_vision/binary_sensor.py
+++ b/custom_components/watts_vision/binary_sensor.py
@@ -51,7 +51,7 @@ class WattsVisionHeatingBinarySensor(BinarySensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = "Heating " + zone
+        self._name = zone + " Heating"
         self._state: bool = False
         self._available = True
 

--- a/custom_components/watts_vision/climate.py
+++ b/custom_components/watts_vision/climate.py
@@ -68,7 +68,7 @@ class WattsThermostat(ClimateEntity):
         self.id = id
         self.zone = zone
         self.deviceID = deviceID
-        self._name = "Thermostat " + zone
+        self._name = zone + " Thermostat"
         self._available = True
         self._attr_extra_state_attributes = {"previous_gv_mode": "0"}
 

--- a/custom_components/watts_vision/climate.py
+++ b/custom_components/watts_vision/climate.py
@@ -18,7 +18,6 @@ from .const import (
     DOMAIN,
     PRESET_MODE_MAP,
     PRESET_MODE_REVERSE_MAP,
-    PRESET_OFF,
     _AVAILABLE_HEAT_MODES,
     _AVAILABLE_TEMP_TYPES,
     _DEVICE_TO_MODE_TYPE,
@@ -210,7 +209,7 @@ class WattsThermostat(ClimateEntity):
             self._attr_extra_state_attributes["previous_gv_mode"] = (
                 self._attr_extra_state_attributes["gv_mode"]
             )
-            mode = PRESET_MODE_REVERSE_MAP[PRESET_OFF]
+            mode = _HEAT_MODE_TO_DEVICE[HeatMode.OFF]
             consigne = "Off"
             value = 0
 

--- a/custom_components/watts_vision/climate.py
+++ b/custom_components/watts_vision/climate.py
@@ -19,6 +19,8 @@ from .const import (
     PRESET_MODE_MAP,
     PRESET_MODE_REVERSE_MAP,
     PRESET_OFF,
+    _AVAILABLE_HEAT_MODES,
+    _DEVICE_TO_MODE_TYPE,
 )
 from .watts_api import WattsApi
 
@@ -107,7 +109,7 @@ class WattsThermostat(ClimateEntity):
     @property
     def preset_modes(self) -> list[str]:
         """Return the available presets."""
-        return list(PRESET_MODE_MAP.values())
+        return [mode.value for mode in _AVAILABLE_HEAT_MODES]
 
     @property
     def preset_mode(self) -> str:
@@ -148,7 +150,7 @@ class WattsThermostat(ClimateEntity):
         else:
             self._attr_hvac_action = HVACAction.HEATING
 
-        self._attr_preset_mode = PRESET_MODE_MAP[smartHomeDevice["gv_mode"]]
+        self._attr_preset_mode = _DEVICE_TO_MODE_TYPE[smartHomeDevice["gv_mode"]].heat_mode
 
         if smartHomeDevice["gv_mode"] == "1":
             self._attr_hvac_mode = HVACMode.OFF
@@ -175,10 +177,11 @@ class WattsThermostat(ClimateEntity):
 
         self._attr_extra_state_attributes["gv_mode"] = smartHomeDevice["gv_mode"]
         _LOGGER.debug(
-            "Update: {} air={} mode {} min {} max {}".format(
+            "Update: {} air={} heat_mode {} temp_type {} min {} max {}".format(
                 self._name,
                 self._attr_current_temperature,
-                PRESET_MODE_MAP[smartHomeDevice["gv_mode"]],
+                _DEVICE_TO_MODE_TYPE[smartHomeDevice["gv_mode"]].heat_mode,
+                _DEVICE_TO_MODE_TYPE[smartHomeDevice["gv_mode"]].temp_type,
                 self._attr_min_temp,
                 self._attr_max_temp,
             )

--- a/custom_components/watts_vision/climate.py
+++ b/custom_components/watts_vision/climate.py
@@ -20,7 +20,9 @@ from .const import (
     PRESET_MODE_REVERSE_MAP,
     PRESET_OFF,
     _AVAILABLE_HEAT_MODES,
+    _AVAILABLE_TEMP_TYPES,
     _DEVICE_TO_MODE_TYPE,
+    _TEMP_TYPE_TO_DEVICE,
 )
 from .watts_api import WattsApi
 
@@ -161,12 +163,12 @@ class WattsThermostat(ClimateEntity):
                 self._attr_hvac_mode = HVACMode.COOL
             else:
                 self._attr_hvac_mode = HVACMode.HEAT
-            consigne = CONSIGNE_MAP[smartHomeDevice["gv_mode"]]
+            consigne = _TEMP_TYPE_TO_DEVICE[_DEVICE_TO_MODE_TYPE[smartHomeDevice["gv_mode"]].temp_type]
             self._attr_target_temperature = float(smartHomeDevice[consigne]) / 10
             targettemp = self._attr_target_temperature
 
         logstring = f"Update: {self._name} targettemp={targettemp}"
-        for consigne in CONSIGNE_MAP.values():
+        for consigne in [_TEMP_TYPE_TO_DEVICE[mode] for mode in _AVAILABLE_TEMP_TYPES]:
             self._attr_extra_state_attributes[consigne] = (
                 float(smartHomeDevice[consigne]) / 10
             )

--- a/custom_components/watts_vision/climate.py
+++ b/custom_components/watts_vision/climate.py
@@ -201,7 +201,7 @@ class WattsThermostat(ClimateEntity):
                 consigne = "Off"
                 value = 0
             else:
-                consigne = CONSIGNE_MAP[mode]
+                consigne = _TEMP_TYPE_TO_DEVICE[_DEVICE_TO_MODE_TYPE[mode].temp_type]
                 value = int(self._attr_extra_state_attributes[consigne])
 
         if hvac_mode == HVACMode.OFF:
@@ -209,6 +209,7 @@ class WattsThermostat(ClimateEntity):
                 self._attr_extra_state_attributes["gv_mode"]
             )
             mode = PRESET_MODE_REVERSE_MAP[PRESET_OFF]
+            consigne = "Off"
             value = 0
 
         _LOGGER.debug(

--- a/custom_components/watts_vision/const.py
+++ b/custom_components/watts_vision/const.py
@@ -5,8 +5,11 @@ This ensures consistency across the integration.
 """
 
 import logging
+from typing import NamedTuple
+from enum import Enum
 
 from homeassistant.components.climate.const import (
+    PRESET_NONE,
     PRESET_BOOST,
     PRESET_COMFORT,
     PRESET_ECO,
@@ -21,6 +24,94 @@ LOGGER = logging.getLogger(__package__)
 PRESET_DEFROST = "Frost Protection"
 PRESET_OFF = "Off"
 PRESET_PROGRAM = "Program"
+
+class HeatMode(Enum):
+    """Enum of available heating modes."""
+
+    OFF = PRESET_OFF
+    FROST = PRESET_DEFROST
+    COMFORT = PRESET_COMFORT
+    PROGRAM = PRESET_PROGRAM
+    ECO = PRESET_ECO
+    BOOST = PRESET_BOOST
+
+class TempType(Enum):
+    """Enum of available temperatures modes."""
+
+    NONE = PRESET_NONE
+    FROST = PRESET_DEFROST
+    ECO = PRESET_ECO
+    COMFORT = PRESET_COMFORT
+    BOOST = PRESET_BOOST
+    CURRENT = "Current"
+    TARGET = "Target"
+    MANUAL = "Manual"
+
+class _ModeInfo(NamedTuple):
+    heat_mode: HeatMode
+    temp_type: TempType
+
+_DEVICE_TO_MODE_TYPE: dict[str, _ModeInfo] = {
+    "0": _ModeInfo(HeatMode.COMFORT, TempType.COMFORT),
+    "1": _ModeInfo(HeatMode.OFF, TempType.NONE),
+    "2": _ModeInfo(HeatMode.FROST, TempType.FROST),
+    "3": _ModeInfo(HeatMode.ECO, TempType.ECO),
+    "4": _ModeInfo(HeatMode.BOOST, TempType.BOOST),
+    # "5": ModeInfo("fan", None),
+    # "6": ModeInfo("fan-disabled", None),
+    "8": _ModeInfo(HeatMode.PROGRAM, TempType.COMFORT),
+    "11": _ModeInfo(HeatMode.PROGRAM, TempType.ECO),
+    # "13": ModeInfo("program", None),
+    # "15": ModeInfo("manual", "manual"),
+    # "16": ModeInfo("program", "boost"),
+}
+
+_HEAT_MODE_TO_DEVICE: dict[HeatMode, str] = {
+    HeatMode.ECO: "3",
+    HeatMode.FROST: "2",
+    HeatMode.COMFORT: "0",
+    HeatMode.PROGRAM: "11",
+    HeatMode.BOOST: "4",
+    HeatMode.OFF: "1",
+}
+
+_HEAT_MODE_TO_WRITABLE_TEMP_TYPE: dict[HeatMode, TempType] = {
+    HeatMode.ECO: TempType.ECO,
+    HeatMode.FROST: TempType.FROST,
+    HeatMode.COMFORT: TempType.COMFORT,
+    HeatMode.BOOST: TempType.BOOST,
+}
+
+_TEMP_TYPE_TO_DEVICE: dict[TempType, str] = {
+    TempType.ECO: "consigne_eco",
+    TempType.FROST: "consigne_hg",
+    TempType.COMFORT: "consigne_confort",
+    TempType.CURRENT: "temperature_air",
+    TempType.MANUAL: "consigne_manuel",
+    TempType.BOOST: "consigne_boost",
+}
+
+_AVAILABLE_TEMP_TYPES: list[TempType] = [
+    TempType.ECO,
+    TempType.FROST,
+    TempType.COMFORT,
+    TempType.CURRENT,
+    TempType.BOOST,
+]
+
+_READONLY_TEMP_TYPES: list[TempType] = [
+    TempType.CURRENT,
+    TempType.TARGET,
+]
+
+_AVAILABLE_HEAT_MODES: list[HeatMode] = [
+    HeatMode.COMFORT,
+    HeatMode.ECO,
+    HeatMode.FROST,
+    HeatMode.PROGRAM,
+    HeatMode.BOOST,
+    HeatMode.OFF,
+]
 
 PRESET_MODE_MAP = {
     "0": PRESET_COMFORT,

--- a/custom_components/watts_vision/const.py
+++ b/custom_components/watts_vision/const.py
@@ -46,5 +46,6 @@ CONSIGNE_MAP = {
     "2": "consigne_hg",
     "3": "consigne_eco",
     "4": "consigne_boost",
-    "11": "consigne_manuel",
+    "8": "consigne_confort",
+    "11": "consigne_eco",
 }

--- a/custom_components/watts_vision/const.py
+++ b/custom_components/watts_vision/const.py
@@ -28,6 +28,7 @@ PRESET_MODE_MAP = {
     "2": PRESET_DEFROST,
     "3": PRESET_ECO,
     "4": PRESET_BOOST,
+    "8": PRESET_PROGRAM,
     "11": PRESET_PROGRAM,
 }
 

--- a/custom_components/watts_vision/const.py
+++ b/custom_components/watts_vision/const.py
@@ -112,31 +112,3 @@ _AVAILABLE_HEAT_MODES: list[HeatMode] = [
     HeatMode.BOOST,
     HeatMode.OFF,
 ]
-
-PRESET_MODE_MAP = {
-    "0": PRESET_COMFORT,
-    "1": PRESET_OFF,
-    "2": PRESET_DEFROST,
-    "3": PRESET_ECO,
-    "4": PRESET_BOOST,
-    "8": PRESET_PROGRAM,
-    "11": PRESET_PROGRAM,
-}
-
-PRESET_MODE_REVERSE_MAP = {
-    PRESET_COMFORT: "0",
-    PRESET_OFF: "1",
-    PRESET_DEFROST: "2",
-    PRESET_ECO: "3",
-    PRESET_BOOST: "4",
-    PRESET_PROGRAM: "11",
-}
-
-CONSIGNE_MAP = {
-    "0": "consigne_confort",
-    "2": "consigne_hg",
-    "3": "consigne_eco",
-    "4": "consigne_boost",
-    "8": "consigne_confort",
-    "11": "consigne_eco",
-}

--- a/custom_components/watts_vision/sensor.py
+++ b/custom_components/watts_vision/sensor.py
@@ -87,7 +87,7 @@ class WattsVisionThermostatSensor(SensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = "Heating mode " + zone
+        self._name = zone + " Heating mode"
         self._state = None
         self._available = True
 
@@ -147,7 +147,7 @@ class WattsVisionBatterySensor(SensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = "Battery " + zone
+        self._name = zone + " Battery"
         self._state = None
         self._available = None
 
@@ -201,7 +201,7 @@ class WattsVisionTemperatureSensor(SensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = "Air temperature " + zone
+        self._name = zone + " Air temperature"
         self._state = None
         self._available = True
 
@@ -262,7 +262,7 @@ class WattsVisionSetTemperatureSensor(SensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = "Target temperature " + zone
+        self._name = zone + " Target temperature"
         self._state = None
         self._available = True
 

--- a/custom_components/watts_vision/sensor.py
+++ b/custom_components/watts_vision/sensor.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
                     if smartHomes[y]["zones"][z]["devices"] is not None:
                         for x in range(len(smartHomes[y]["zones"][z]["devices"])):
                             sensors.append(
-                                WattsVisionThermostatSensor(
+                                WattsVisionPresetModeSensor(
                                     wattsClient,
                                     smartHomes[y]["smarthome_id"],
                                     smartHomes[y]["zones"][z]["devices"][x]["id"],
@@ -84,7 +84,7 @@ async def async_setup_entry(
     async_add_entities(sensors, update_before_add=True)
 
 
-class WattsVisionThermostatSensor(SensorEntity):
+class WattsVisionPresetModeSensor(SensorEntity):
     """Representation of a Watts Vision thermostat."""
 
     def __init__(self, wattsClient: WattsApi, smartHome: str, id: str, zone: str):
@@ -93,7 +93,7 @@ class WattsVisionThermostatSensor(SensorEntity):
         self.smartHome = smartHome
         self.id = id
         self.zone = zone
-        self._name = zone + " Heating mode"
+        self._name = zone + " Preset mode"
         self._state = None
         self._available = True
 

--- a/custom_components/watts_vision/sensor.py
+++ b/custom_components/watts_vision/sensor.py
@@ -12,11 +12,11 @@ from homeassistant.core import HomeAssistant
 from .central_unit import WattsVisionLastCommunicationSensor
 from .const import (
     API_CLIENT,
-    CONSIGNE_MAP,
     DOMAIN,
     _AVAILABLE_HEAT_MODES,
     _AVAILABLE_TEMP_TYPES,
     _DEVICE_TO_MODE_TYPE,
+    _TEMP_TYPE_TO_DEVICE,
 )
 from .watts_api import WattsApi
 
@@ -381,7 +381,7 @@ class WattsVisionSetTemperatureSensor(SensorEntity):
         if smartHomeDevice["gv_mode"] == "1":
             self._state = NaN
         else:
-            value = int(smartHomeDevice[CONSIGNE_MAP[smartHomeDevice["gv_mode"]]])
+            value = int(smartHomeDevice[_TEMP_TYPE_TO_DEVICE[_DEVICE_TO_MODE_TYPE[smartHomeDevice["gv_mode"]].temp_type]])
             if self.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS:
                 self._state = round((value - 320) * 5 / 9 / 10, 1)
             else:

--- a/custom_components/watts_vision/sensor.py
+++ b/custom_components/watts_vision/sensor.py
@@ -10,7 +10,13 @@ from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 
 from .central_unit import WattsVisionLastCommunicationSensor
-from .const import API_CLIENT, CONSIGNE_MAP, DOMAIN, PRESET_MODE_MAP
+from .const import (
+    API_CLIENT,
+    CONSIGNE_MAP,
+    DOMAIN,
+    _AVAILABLE_HEAT_MODES,
+    _DEVICE_TO_MODE_TYPE,
+)
 from .watts_api import WattsApi
 
 _LOGGER = logging.getLogger(__name__)
@@ -111,7 +117,7 @@ class WattsVisionThermostatSensor(SensorEntity):
 
     @property
     def options(self):
-        return list(PRESET_MODE_MAP.values())
+        return [mode.value.capitalize() for mode in _AVAILABLE_HEAT_MODES]
 
     @property
     def device_info(self):
@@ -131,7 +137,7 @@ class WattsVisionThermostatSensor(SensorEntity):
         # try:
         smartHomeDevice = self.client.getDevice(self.smartHome, self.id)
 
-        self._state = PRESET_MODE_MAP[smartHomeDevice["gv_mode"]]
+        self._state = _DEVICE_TO_MODE_TYPE[smartHomeDevice["gv_mode"]].heat_mode.value.capitalize()
 
         # except:
         #     self._available = False


### PR DESCRIPTION
This is the full fix for https://github.com/NoWarries/watts_vision/issues/21, build on top of https://github.com/NoWarries/watts_vision/pull/22 and https://github.com/NoWarries/watts_vision/pull/23

It is very much based on the code for Clevertouch branded equipment: https://github.com/hemphen/clevertouch

End result is correctly showing the preset/program mode as well as temperature mode when in program mode. 
Temperature mode is available as separate sensor.