### PR TITLE
Replace deprecated PERCENTAGE constant

### DIFF
--- a/custom_components/watts_vision/sensor.py
+++ b/custom_components/watts_vision/sensor.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.const import UnitOfRatio, UnitOfTemperature
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 
 from .const import (
@@ -172,7 +172,7 @@ class WattsVisionBatterySensor(WattsVisionDeviceSensor):
     """Represent the Watts Vision device battery state."""
 
     _attr_device_class = SensorDeviceClass.BATTERY
-    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_native_unit_of_measurement = UnitOfRatio.PERCENTAGE
     _attr_translation_key = "battery"
 
     def __init__(


### PR DESCRIPTION
## Summary

Replace the deprecated `PERCENTAGE` unit constant with `UnitOfRatio.PERCENTAGE` for the battery sensor.

## Scope

- Home Assistant compatibility cleanup only
- No functional changes
- No HACS, workflow, or licensing changes

## Changes

- Import `UnitOfRatio`
- Use `UnitOfRatio.PERCENTAGE` as the native unit of measurement